### PR TITLE
Add file extension initialization parameter to RQESService and related classes. Remove RQESService defaultSigningAlgorithm init parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,7 @@ let cscClientConfig = CSCClientConfig(
 )
 var rqesService = RQESService(
     clientConfig: cscClientConfig,
-    defaultHashAlgorithmOID: .SHA256,
-    defaultSigningAlgorithmOID: .RSA
+    defaultHashAlgorithmOID: .SHA256
 )
 ```
 

--- a/Sources/RqesKit/RQESService.swift
+++ b/Sources/RqesKit/RQESService.swift
@@ -38,7 +38,6 @@ public class RQESService: RQESServiceProtocol, @unchecked Sendable {
 	/// Initialize the RQES service
 	/// - Parameter clientConfig: CSC client configuration
 	/// - Parameter defaultHashAlgorithmOID: The default hash algorithm OID
-	/// - Parameter defaultSigningAlgorithmOID: The default signing algorithm OID
 	/// - Parameter fileExtension: The file extension to be used for the signed documents
 	required public init(clientConfig: CSCClientConfig, defaultHashAlgorithmOID: HashAlgorithmOID = .SHA256, fileExtension: String = ".pdf") {
 		self.clientConfig = clientConfig

--- a/Sources/RqesKit/RQESService.swift
+++ b/Sources/RqesKit/RQESService.swift
@@ -32,7 +32,7 @@ public class RQESService: RQESServiceProtocol, @unchecked Sendable {
 	var state: String?
 	var rqes: RQES!
 	var defaultHashAlgorithmOID: HashAlgorithmOID
-	var defaultSigningAlgorithmOID: SigningAlgorithmOID
+	var defaultSigningAlgorithmOID: SigningAlgorithmOID?
 	var fileExtension: String
 
 	/// Initialize the RQES service
@@ -40,10 +40,9 @@ public class RQESService: RQESServiceProtocol, @unchecked Sendable {
 	/// - Parameter defaultHashAlgorithmOID: The default hash algorithm OID
 	/// - Parameter defaultSigningAlgorithmOID: The default signing algorithm OID
 	/// - Parameter fileExtension: The file extension to be used for the signed documents
-	required public init(clientConfig: CSCClientConfig, defaultHashAlgorithmOID: HashAlgorithmOID = .SHA256, defaultSigningAlgorithmOID: SigningAlgorithmOID = .RSA, fileExtension: String = ".pdf") {
+	required public init(clientConfig: CSCClientConfig, defaultHashAlgorithmOID: HashAlgorithmOID = .SHA256, fileExtension: String = ".pdf") {
 		self.clientConfig = clientConfig
 		self.defaultHashAlgorithmOID = defaultHashAlgorithmOID
-		self.defaultSigningAlgorithmOID = defaultSigningAlgorithmOID
 		self.fileExtension = fileExtension
 	}
 	
@@ -55,6 +54,7 @@ public class RQESService: RQESServiceProtocol, @unchecked Sendable {
 		// STEP 2: Retrieve service information using the InfoService
 		let request = InfoServiceRequest(lang: "en-US")
 		let response = try await rqes.getInfo(request: request)
+		if let algo = response.signAlgorithms.algos.first { defaultSigningAlgorithmOID = SigningAlgorithmOID(rawValue: algo) }
 		return response
 	}
 	

--- a/Sources/RqesKit/RQESService.swift
+++ b/Sources/RqesKit/RQESService.swift
@@ -37,6 +37,9 @@ public class RQESService: RQESServiceProtocol, @unchecked Sendable {
 
 	/// Initialize the RQES service
 	/// - Parameter clientConfig: CSC client configuration
+	/// - Parameter defaultHashAlgorithmOID: The default hash algorithm OID
+	/// - Parameter defaultSigningAlgorithmOID: The default signing algorithm OID
+	/// - Parameter fileExtension: The file extension to be used for the signed documents
 	required public init(clientConfig: CSCClientConfig, defaultHashAlgorithmOID: HashAlgorithmOID = .SHA256, defaultSigningAlgorithmOID: SigningAlgorithmOID = .RSA, fileExtension: String = ".pdf") {
 		self.clientConfig = clientConfig
 		self.defaultHashAlgorithmOID = defaultHashAlgorithmOID

--- a/Sources/RqesKit/RQESServiceAuthorized.swift
+++ b/Sources/RqesKit/RQESServiceAuthorized.swift
@@ -33,10 +33,10 @@ public class RQESServiceAuthorized: RQESServiceAuthorizedProtocol, @unchecked Se
     var authorizationDetailsJsonString: String?
 	var hashAlgorithmOID: HashAlgorithmOID?
 	var defaultHashAlgorithmOID: HashAlgorithmOID
-	var defaultSigningAlgorithmOID: SigningAlgorithmOID
+	var defaultSigningAlgorithmOID: SigningAlgorithmOID?
 	var fileExtension: String
 
-    public init(_ rqes: RQES, clientConfig: CSCClientConfig, defaultHashAlgorithmOID: HashAlgorithmOID, defaultSigningAlgorithmOID: SigningAlgorithmOID, fileExtension: String, state: String, accessToken: String) {
+    public init(_ rqes: RQES, clientConfig: CSCClientConfig, defaultHashAlgorithmOID: HashAlgorithmOID, defaultSigningAlgorithmOID: SigningAlgorithmOID?, fileExtension: String, state: String, accessToken: String) {
 		self.rqes = rqes
         self.clientConfig = clientConfig
 		self.defaultHashAlgorithmOID = defaultHashAlgorithmOID

--- a/Sources/RqesKit/RQESServiceAuthorized.swift
+++ b/Sources/RqesKit/RQESServiceAuthorized.swift
@@ -33,12 +33,14 @@ public class RQESServiceAuthorized: RQESServiceAuthorizedProtocol, @unchecked Se
 	var hashAlgorithmOID: HashAlgorithmOID?
 	var defaultHashAlgorithmOID: HashAlgorithmOID
 	var defaultSigningAlgorithmOID: SigningAlgorithmOID
+	var fileExtension: String
 
-    public init(_ rqes: RQES, clientConfig: CSCClientConfig, defaultHashAlgorithmOID: HashAlgorithmOID, defaultSigningAlgorithmOID: SigningAlgorithmOID, state: String, accessToken: String, baseProviderUrl: String) {
+    public init(_ rqes: RQES, clientConfig: CSCClientConfig, defaultHashAlgorithmOID: HashAlgorithmOID, defaultSigningAlgorithmOID: SigningAlgorithmOID, fileExtension: String, state: String, accessToken: String) {
 		self.rqes = rqes
         self.clientConfig = clientConfig
 		self.defaultHashAlgorithmOID = defaultHashAlgorithmOID
 		self.defaultSigningAlgorithmOID = defaultSigningAlgorithmOID
+		self.fileExtension = fileExtension
 		self.state = state
 		self.accessToken = accessToken
     }
@@ -86,6 +88,6 @@ public class RQESServiceAuthorized: RQESServiceAuthorizedProtocol, @unchecked Se
         let tokenCredentialRequest = OAuth2TokenDto(code: authorizationCode, state: state, authorizationDetails: authorizationDetailsJsonString)
         let tokenCredentialResponse = try await rqes.getOAuth2Token(request: tokenCredentialRequest)
 		let credentialAccessToken = tokenCredentialResponse.accessToken
-		return RQESServiceCredentialAuthorized(rqes: rqes, clientConfig: clientConfig, credentialInfo: credentialInfo!, credentialAccessToken: credentialAccessToken, documents: documents!, calculateHashResponse: calculateHashResponse!, hashAlgorithmOID: hashAlgorithmOID!, defaultSigningAlgorithmOID: defaultSigningAlgorithmOID)
+		return RQESServiceCredentialAuthorized(rqes: rqes, clientConfig: clientConfig, credentialInfo: credentialInfo!, credentialAccessToken: credentialAccessToken, documents: documents!, calculateHashResponse: calculateHashResponse!, hashAlgorithmOID: hashAlgorithmOID!, defaultSigningAlgorithmOID: defaultSigningAlgorithmOID, fileExtension: fileExtension)
 	}
 }

--- a/Sources/RqesKit/RQESServiceAuthorized.swift
+++ b/Sources/RqesKit/RQESServiceAuthorized.swift
@@ -20,6 +20,7 @@ import CommonCrypto
 import X509
 import SwiftASN1
 
+/// The authorized service is used to access the user's credentials
 public class RQESServiceAuthorized: RQESServiceAuthorizedProtocol, @unchecked Sendable {
 
     var rqes: RQES

--- a/Sources/RqesKit/RQESServiceCredentialAuthorized.swift
+++ b/Sources/RqesKit/RQESServiceCredentialAuthorized.swift
@@ -32,8 +32,9 @@ public class RQESServiceCredentialAuthorized: RQESServiceCredentialAuthorizedPro
     var calculateHashResponse: CalculateHashResponse
     var hashAlgorithmOID: HashAlgorithmOID
     var defaultSigningAlgorithmOID: SigningAlgorithmOID
+    var fileExtension: String
  
-    public init(rqes: RQES, clientConfig: CSCClientConfig, credentialInfo: CredentialInfo, credentialAccessToken: String, documents: [Document], calculateHashResponse: CalculateHashResponse, hashAlgorithmOID: HashAlgorithmOID, defaultSigningAlgorithmOID: SigningAlgorithmOID) {
+    public init(rqes: RQES, clientConfig: CSCClientConfig, credentialInfo: CredentialInfo, credentialAccessToken: String, documents: [Document], calculateHashResponse: CalculateHashResponse, hashAlgorithmOID: HashAlgorithmOID, defaultSigningAlgorithmOID: SigningAlgorithmOID, fileExtension: String) {
         self.rqes = rqes
         self.clientConfig = clientConfig
         self.credentialInfo = credentialInfo
@@ -42,6 +43,7 @@ public class RQESServiceCredentialAuthorized: RQESServiceCredentialAuthorizedPro
         self.calculateHashResponse = calculateHashResponse
         self.hashAlgorithmOID = hashAlgorithmOID
         self.defaultSigningAlgorithmOID = defaultSigningAlgorithmOID
+        self.fileExtension = fileExtension
     }
 
     /// Signs the documents using the specified hash algorithm and certificates.
@@ -65,7 +67,7 @@ public class RQESServiceCredentialAuthorized: RQESServiceCredentialAuthorizedPro
 				endEntityCertificate: certs.first!, certificateChain: Array(certs.dropFirst()), hashAlgorithmOID: hashAlgorithmOID, date: calculateHashResponse.signatureDate, signatures: signHashResponse.signatures ?? [])
 		let obtainSignedDocResponse = try await rqes.obtainSignedDoc(request: obtainSignedDocRequest, accessToken: credentialAccessToken)
 
-		let documentsWithSignature = obtainSignedDocResponse.documentWithSignature.enumerated().map { i, d in Document(id: documents[i].id, fileURL: try! RQESService.saveToTempFile(data: Data(base64Encoded: d)!)) }
+		let documentsWithSignature = obtainSignedDocResponse.documentWithSignature.enumerated().map { i, d in Document(id: documents[i].id, fileURL: try! RQESService.saveToTempFile(data: Data(base64Encoded: d)!, fileExtension: fileExtension)) }
         return documentsWithSignature
 	}
 

--- a/Sources/RqesKit/RQESServiceCredentialAuthorized.swift
+++ b/Sources/RqesKit/RQESServiceCredentialAuthorized.swift
@@ -31,10 +31,10 @@ public class RQESServiceCredentialAuthorized: RQESServiceCredentialAuthorizedPro
     var documents: [Document]
     var calculateHashResponse: CalculateHashResponse
     var hashAlgorithmOID: HashAlgorithmOID
-    var defaultSigningAlgorithmOID: SigningAlgorithmOID
+    var defaultSigningAlgorithmOID: SigningAlgorithmOID?
     var fileExtension: String
  
-    public init(rqes: RQES, clientConfig: CSCClientConfig, credentialInfo: CredentialInfo, credentialAccessToken: String, documents: [Document], calculateHashResponse: CalculateHashResponse, hashAlgorithmOID: HashAlgorithmOID, defaultSigningAlgorithmOID: SigningAlgorithmOID, fileExtension: String) {
+    public init(rqes: RQES, clientConfig: CSCClientConfig, credentialInfo: CredentialInfo, credentialAccessToken: String, documents: [Document], calculateHashResponse: CalculateHashResponse, hashAlgorithmOID: HashAlgorithmOID, defaultSigningAlgorithmOID: SigningAlgorithmOID?, fileExtension: String) {
         self.rqes = rqes
         self.clientConfig = clientConfig
         self.credentialInfo = credentialInfo
@@ -58,7 +58,8 @@ public class RQESServiceCredentialAuthorized: RQESServiceCredentialAuthorizedPro
     /// that were passed to the ``RQESServiceAuthorizedProtocol.getCredentialAuthorizationUrl`` method.
 	public func signDocuments(signAlgorithmOID: SigningAlgorithmOID? = nil, certificates: [X509.Certificate]? = nil) async throws -> [Document] {
 		// STEP 12: Sign the calculated hash with the credential
-		let signHashRequest = SignHashRequest(credentialID: credentialInfo.credentialID, hashes: calculateHashResponse.hashes, hashAlgorithmOID: hashAlgorithmOID, signAlgo: signAlgorithmOID ?? defaultSigningAlgorithmOID, operationMode: "S")
+        guard let signAlgo = signAlgorithmOID ?? defaultSigningAlgorithmOID else { throw NSError(domain: "RQES", code: 0, userInfo: [NSLocalizedDescriptionKey: "No signing algorithm provided"]) }
+		let signHashRequest = SignHashRequest(credentialID: credentialInfo.credentialID, hashes: calculateHashResponse.hashes, hashAlgorithmOID: hashAlgorithmOID, signAlgo: signAlgo, operationMode: "S")
 		let signHashResponse = try await rqes.signHash(request: signHashRequest, accessToken: credentialAccessToken)
 		let certs = certificates?.map(\.base64String) ?? credentialInfo.cert.certificates
 		// STEP 13: Obtain the signed document

--- a/Sources/RqesKit/RqesProtocols.swift
+++ b/Sources/RqesKit/RqesProtocols.swift
@@ -26,9 +26,8 @@ public protocol RQESServiceProtocol {
 	/// Initialize the RQES service
 	/// - Parameter clientConfig: CSC client configuration
 	/// - Parameter defaultHashAlgorithmOID: The default hash algorithm OID
-	/// - Parameter defaultSigningAlgorithmOID: The default signing algorithm OID
 	/// - Parameter fileExtension: The file extension to be used for the signed documents
-	init(clientConfig: CSCClientConfig, defaultHashAlgorithmOID: HashAlgorithmOID, defaultSigningAlgorithmOID: SigningAlgorithmOID, fileExtension: String)
+	init(clientConfig: CSCClientConfig, defaultHashAlgorithmOID: HashAlgorithmOID, fileExtension: String)
 	/// Retrieve the RSSP metadata
 	func getRSSPMetadata() async throws -> RSSPMetadata
 	/// Retrieve the service authorization URL

--- a/Sources/RqesKit/RqesProtocols.swift
+++ b/Sources/RqesKit/RqesProtocols.swift
@@ -25,7 +25,7 @@ public protocol RQESServiceProtocol {
 	associatedtype RQESServiceAuthorizedImpl: RQESServiceAuthorizedProtocol
 	/// Initialize the RQES service
 	/// - Parameter clientConfig: CSC client configuration
-	init(clientConfig: CSCClientConfig, defaultHashAlgorithmOID: HashAlgorithmOID, defaultSigningAlgorithmOID: SigningAlgorithmOID)
+	init(clientConfig: CSCClientConfig, defaultHashAlgorithmOID: HashAlgorithmOID, defaultSigningAlgorithmOID: SigningAlgorithmOID, fileExtension: String)
 	/// Retrieve the RSSP metadata
 	func getRSSPMetadata() async throws -> RSSPMetadata
 	/// Retrieve the service authorization URL

--- a/Sources/RqesKit/RqesProtocols.swift
+++ b/Sources/RqesKit/RqesProtocols.swift
@@ -25,6 +25,9 @@ public protocol RQESServiceProtocol {
 	associatedtype RQESServiceAuthorizedImpl: RQESServiceAuthorizedProtocol
 	/// Initialize the RQES service
 	/// - Parameter clientConfig: CSC client configuration
+	/// - Parameter defaultHashAlgorithmOID: The default hash algorithm OID
+	/// - Parameter defaultSigningAlgorithmOID: The default signing algorithm OID
+	/// - Parameter fileExtension: The file extension to be used for the signed documents
 	init(clientConfig: CSCClientConfig, defaultHashAlgorithmOID: HashAlgorithmOID, defaultSigningAlgorithmOID: SigningAlgorithmOID, fileExtension: String)
 	/// Retrieve the RSSP metadata
 	func getRSSPMetadata() async throws -> RSSPMetadata

--- a/Tests/RqesKitTests/RqesKitTests.swift
+++ b/Tests/RqesKitTests/RqesKitTests.swift
@@ -13,3 +13,17 @@ import SwiftASN1
     #expect(ser.serializedBytes == certData)
     #expect(Data(ser.serializedBytes).base64EncodedString() == certBase64)
 }
+
+@Test func ensureDefaultSignAlgorithmExists() async throws {
+    let cscClientConfig = CSCClientConfig(
+        OAuth2Client: CSCClientConfig.OAuth2Client(clientId: "wallet-client", clientSecret: "somesecret2"),
+        authFlowRedirectionURI: "https://oauthdebugger.com/debug",
+        scaBaseURL: "https://walletcentric.signer.eudiw.dev"
+)
+    let rqesService = RQESService(clientConfig: cscClientConfig, defaultHashAlgorithmOID: .SHA256)
+    let rsspMetadata = try await rqesService.getRSSPMetadata()
+    #expect(rsspMetadata.signAlgorithms.algos.count > 0)
+    #expect(rqesService.defaultSigningAlgorithmOID != nil)
+    print("Default signing algorithm: \(rsspMetadata.signAlgorithms.algos.first ?? "")")
+    
+}


### PR DESCRIPTION
Introduce a file extension parameter to the RQESService and related classes, allowing for more flexibility in file handling. Update initializers and methods to accommodate this new parameter.