### PR TITLE
Update eudi-lib-ios-rqes-csc-swift to version 0.3.0

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,13 +1,22 @@
 {
-  "originHash" : "3fbeb1964345ca33e415c6cc72b5c8f4b4ce0b72e31041ca86ed1711dc8acc63",
+  "originHash" : "efc673f9208f99e0898d6ba36f27da58a8ed310f885e2aa2e97f6d3e4a9922b4",
   "pins" : [
     {
       "identity" : "eudi-lib-ios-rqes-csc-swift",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-rqes-csc-swift.git",
       "state" : {
-        "revision" : "9e192796a8df9b11d3b463b56289a1220bbeb010",
-        "version" : "0.2.1"
+        "revision" : "e055fa029d84931d4c8c4354bfe1913ee653bc44",
+        "version" : "0.3.0"
+      }
+    },
+    {
+      "identity" : "eudi-lib-podofo",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/eu-digital-identity-wallet/eudi-lib-podofo",
+      "state" : {
+        "revision" : "8e2575abb9f393cae43ae5fd9a8f2e8dd962f12a",
+        "version" : "0.1.2"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        .package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-rqes-csc-swift.git", exact: "0.2.1"),
+        .package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-rqes-csc-swift.git", exact: "0.3.0"),
         .package(url: "https://github.com/apple/swift-certificates.git", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.5.3"),
     ],


### PR DESCRIPTION
Upgrade the eudi-lib-ios-rqes-csc-swift dependency to version 0.3.0 and adjust the Package.resolved file accordingly.