### PR TITLE
Update eudi-lib-ios-rqes-csc-swift to 0.3.1 and enhance RQES service

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "efc673f9208f99e0898d6ba36f27da58a8ed310f885e2aa2e97f6d3e4a9922b4",
+  "originHash" : "cba646786a9b0de9307ba3741db9f5ae1943ab9fd356c14a05ad44f3b7a17b6e",
   "pins" : [
     {
       "identity" : "eudi-lib-ios-rqes-csc-swift",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-rqes-csc-swift.git",
       "state" : {
-        "revision" : "e055fa029d84931d4c8c4354bfe1913ee653bc44",
-        "version" : "0.3.0"
+        "revision" : "c65496732d64d7bbb72f9f4934b7a091770a2478",
+        "version" : "0.3.1"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        .package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-rqes-csc-swift.git", exact: "0.3.0"),
+        .package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-rqes-csc-swift.git", exact: "0.3.1"),
         .package(url: "https://github.com/apple/swift-certificates.git", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.5.3"),
     ],
@@ -24,7 +24,7 @@ let package = Package(
         // Targets can depend on other targets in this package and products from dependencies.
         .target(
             name: "RqesKit", dependencies: [
-                .product(name: "RQES_LIBRARY", package: "eudi-lib-ios-rqes-csc-swift"),
+                .product(name: "RQESLib", package: "eudi-lib-ios-rqes-csc-swift"),
                 .product(name: "X509", package: "swift-certificates"),
                  .product(name: "Logging", package: "swift-log")
             ]),

--- a/README.md
+++ b/README.md
@@ -60,9 +60,7 @@ let cscClientConfig = CSCClientConfig(
                 clientId: "wallet-client",
                 clientSecret: "somesecret2"
         ),
-        authFlowRedirectionURI: "https://oauthdebugger.com/debug",
-        scaBaseURL: "https://walletcentric.signer.eudiw.dev"
-)
+        authFlowRedirectionURI: "https://oauthdebugger.com/debug", rsspId: "")
 var rqesService = RQESService(
     clientConfig: cscClientConfig,
     defaultHashAlgorithmOID: .SHA256

--- a/Sources/RqesKit/RQESService.swift
+++ b/Sources/RqesKit/RQESService.swift
@@ -15,15 +15,15 @@
  */
 
 import Foundation
-import RQES_LIBRARY
+import RQESLib
 import CommonCrypto
 import X509
 import SwiftASN1
 
-public typealias CSCClientConfig = RQES_LIBRARY.CSCClientConfig
-public typealias RSSPMetadata = RQES_LIBRARY.InfoServiceResponse
+public typealias CSCClientConfig = RQESLib.CSCClientConfig
+public typealias RSSPMetadata = RQESLib.InfoServiceResponse
 public typealias CredentialInfo = CredentialsListResponse.CredentialInfo
-public typealias HashAlgorithmOID = RQES_LIBRARY.HashAlgorithmOID
+public typealias HashAlgorithmOID = RQESLib.HashAlgorithmOID
 
  // ---------------------------
 public class RQESService: RQESServiceProtocol, @unchecked Sendable {
@@ -32,29 +32,18 @@ public class RQESService: RQESServiceProtocol, @unchecked Sendable {
 	var state: String?
 	var rqes: RQES!
 	var defaultHashAlgorithmOID: HashAlgorithmOID
-	var defaultSigningAlgorithmOID: SigningAlgorithmOID?
+	var defaultSigningAlgorithmOID: SigningAlgorithmOID
 	var fileExtension: String
 
 	/// Initialize the RQES service
-	/// - Parameter clientConfig: CSC client configuration (R5: must include tsaUrl for PAdES B-T support)
+	/// - Parameter clientConfig: CSC client configuration
 	/// - Parameter defaultHashAlgorithmOID: The default hash algorithm OID
 	/// - Parameter fileExtension: The file extension to be used for the signed documents
-	required public init(clientConfig: CSCClientConfig, defaultHashAlgorithmOID: HashAlgorithmOID = .SHA256, fileExtension: String = ".pdf") {
+	required public init(clientConfig: CSCClientConfig, defaultHashAlgorithmOID: HashAlgorithmOID = .SHA256, defaultSigningAlgorithmOID: SigningAlgorithmOID = .SHA256WithRSA, fileExtension: String = ".pdf") {
 		self.clientConfig = clientConfig
 		self.defaultHashAlgorithmOID = defaultHashAlgorithmOID
+		self.defaultSigningAlgorithmOID = defaultSigningAlgorithmOID
 		self.fileExtension = fileExtension
-	}
-	
-	/// Retrieve the RSSP metadata
-	public func getRSSPMetadata() async throws -> RSSPMetadata {
-		// STEP 1: Initialize an instance of RQES to access library services
-		// This initializes the RQES object for invoking various service methods
-		rqes = await RQES(cscClientConfig: clientConfig)
-		// STEP 2: Retrieve service information using the InfoService
-		let request = InfoServiceRequest(lang: "en-US")
-		let response = try await rqes.getInfo(request: request)
-		if let algo = response.signAlgorithms.algos.first { defaultSigningAlgorithmOID = SigningAlgorithmOID(rawValue: algo) }
-		return response
 	}
 	
 	/// Retrieve the service authorization URL

--- a/Sources/RqesKit/RQESServiceAuthorized.swift
+++ b/Sources/RqesKit/RQESServiceAuthorized.swift
@@ -15,7 +15,7 @@
  */
 
 import Foundation
-import RQES_LIBRARY
+import RQESLib
 import CommonCrypto
 import X509
 import SwiftASN1

--- a/Sources/RqesKit/RQESServiceCredentialAuthorized.swift
+++ b/Sources/RqesKit/RQESServiceCredentialAuthorized.swift
@@ -15,12 +15,12 @@
  */
 
 import Foundation
-import RQES_LIBRARY
+import RQESLib
 import CommonCrypto
 import X509
 import SwiftASN1
 
-public typealias SigningAlgorithmOID = RQES_LIBRARY.SigningAlgorithmOID
+public typealias SigningAlgorithmOID = RQESLib.SigningAlgorithmOID
 /// The authorized credential is used to sign the documents. The list of documents that will be signed using the authorized credential are the documents
 /// that were passed to the ``RQESServiceAuthorizedProtocol.getCredentialAuthorizationUrl`` method.
 public class RQESServiceCredentialAuthorized: RQESServiceCredentialAuthorizedProtocol, @unchecked Sendable {

--- a/Sources/RqesKit/RqesProtocols.swift
+++ b/Sources/RqesKit/RqesProtocols.swift
@@ -15,7 +15,7 @@
  */
 
 import Foundation
-import RQES_LIBRARY
+import RQESLib
 import CommonCrypto
 import X509
 import SwiftASN1
@@ -24,12 +24,10 @@ import SwiftASN1
 public protocol RQESServiceProtocol {
 	associatedtype RQESServiceAuthorizedImpl: RQESServiceAuthorizedProtocol
 	/// Initialize the RQES service
-	/// - Parameter clientConfig: CSC client configuration (R5: must include tsaUrl for PAdES B-T support)
+	/// - Parameter clientConfig: CSC client configuration
 	/// - Parameter defaultHashAlgorithmOID: The default hash algorithm OID
 	/// - Parameter fileExtension: The file extension to be used for the signed documents
-	init(clientConfig: CSCClientConfig, defaultHashAlgorithmOID: HashAlgorithmOID, fileExtension: String)
-	/// Retrieve the RSSP metadata
-	func getRSSPMetadata() async throws -> RSSPMetadata
+	init(clientConfig: CSCClientConfig, defaultHashAlgorithmOID: HashAlgorithmOID, defaultSigningAlgorithmOID: SigningAlgorithmOID, fileExtension: String)
 	/// Retrieve the service authorization URL
 	/// - Returns: The service authorization URL
 	/// The service authorization URL is used to authorize the service to access the user's credentials.

--- a/Tests/RqesKitTests/RqesKitTests.swift
+++ b/Tests/RqesKitTests/RqesKitTests.swift
@@ -14,16 +14,12 @@ import SwiftASN1
     #expect(Data(ser.serializedBytes).base64EncodedString() == certBase64)
 }
 
-@Test func ensureDefaultSignAlgorithmExists() async throws {
+@Test func ensureRQESServiceInitialize() async throws {
     let cscClientConfig = CSCClientConfig(
         OAuth2Client: CSCClientConfig.OAuth2Client(clientId: "wallet-client", clientSecret: "somesecret2"),
-        authFlowRedirectionURI: "https://oauthdebugger.com/debug",
-        scaBaseURL: "https://walletcentric.signer.eudiw.dev"
-)
+		authFlowRedirectionURI: "https://oauthdebugger.com/debug", rsspId: "")
     let rqesService = RQESService(clientConfig: cscClientConfig, defaultHashAlgorithmOID: .SHA256)
-    let rsspMetadata = try await rqesService.getRSSPMetadata()
-    #expect(rsspMetadata.signAlgorithms.algos.count > 0)
     #expect(rqesService.defaultSigningAlgorithmOID != nil)
-    print("Default signing algorithm: \(rsspMetadata.signAlgorithms.algos.first ?? "")")
+    print("Default signing algorithm: \(rqesService.defaultSigningAlgorithmOID?.description ?? "")")
     
 }


### PR DESCRIPTION
Refactor the RQES service to improve handling of signing algorithms and update the dependency to version 0.3.1. This change also includes adjustments to the import statements and type aliases for consistency.