### PR TITLE
Bump eudi-lib-ios-rqes-csc-swift dependency to version 0.6.0

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "cba646786a9b0de9307ba3741db9f5ae1943ab9fd356c14a05ad44f3b7a17b6e",
+  "originHash" : "41cba97c599fb419876cb952ca760afe2f8ac2e5603cdc878a8ae945c1eaf878",
   "pins" : [
     {
       "identity" : "eudi-lib-ios-rqes-csc-swift",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-rqes-csc-swift.git",
       "state" : {
-        "revision" : "c65496732d64d7bbb72f9f4934b7a091770a2478",
-        "version" : "0.3.1"
+        "revision" : "4b781c8e68927a93a1b21e519bd15d8d406d4aab",
+        "version" : "0.6.0"
       }
     },
     {
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/eu-digital-identity-wallet/eudi-lib-podofo",
       "state" : {
-        "revision" : "8e2575abb9f393cae43ae5fd9a8f2e8dd962f12a",
-        "version" : "0.1.2"
+        "revision" : "0e512c6fbbfe2a134d7f69338e67bf5984286f32",
+        "version" : "0.3.1"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        .package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-rqes-csc-swift.git", exact: "0.3.1"),
+        .package(url: "https://github.com/eu-digital-identity-wallet/eudi-lib-ios-rqes-csc-swift.git", exact: "0.6.0"),
         .package(url: "https://github.com/apple/swift-certificates.git", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.5.3"),
     ],


### PR DESCRIPTION
Update the eudi-lib-ios-rqes-csc-swift dependency to the latest version.