### PR TITLE
Update documentation for RQES service methods and parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,6 @@ sequenceDiagram
     participant RQESService
     participant RQESServiceAuthorized
     participant RQESServiceCredentialAuthorized
-    Client ->>+ RQESService: getRSSPMetadata()
-    RQESService -->>- Client: RSSPMetadata
     Client ->>+ RQESService: getServiceAuthorizationUrl()
     RQESService -->>- Client: URL
     Client ->>+ RQESService: authorizeService(authorizationCode)
@@ -56,22 +54,17 @@ At first, construct an instance of the `RQESService` like shown below:
 
 ```swift
 let cscClientConfig = CSCClientConfig(
-        OAuth2Client: CSCClientConfig.OAuth2Client(
-                clientId: "wallet-client",
-                clientSecret: "somesecret2"
-        ),
-        authFlowRedirectionURI: "https://oauthdebugger.com/debug", rsspId: "")
-var rqesService = RQESService(
+    OAuth2Client: CSCClientConfig.OAuth2Client(
+        clientId: "wallet-client",
+        clientSecret: "somesecret2"
+    ),
+    authFlowRedirectionURI: "https://oauthdebugger.com/debug", rsspId: ""
+)
+var rqesService = await RQESService(
     clientConfig: cscClientConfig,
     defaultHashAlgorithmOID: .SHA256
 )
 ```
-
-You can get the metadata of the RQES service by calling the `getRSSPMetadata` method:
-
-```swift
-let metadata = try await rqesService.getRSSPMetadata()
-``` 
 
 To authorize the service, you need to get the authorization URL and open it in a browser. After the
 user has authorized the service, the browser will be redirected to the `redirectUri`,
@@ -106,12 +99,13 @@ let credentials = try await authorizedService.getCredentialsList()
 
 let credential = credentials.first!
 // Prepare the documents to sign
-let unsignedDocuments = [Document(label: "Document to sign", fileURL: Bundle.main.url(forResource: "document", withExtension:"pdf")))]
+let documentURL = Bundle.main.url(forResource: "document", withExtension: "pdf")!
+let unsignedDocuments = [Document(id: "Document to sign", fileURL: documentURL)]
 
 // Get the credential authorization URL for the selected credential and documents
 let credentialAuthorizationUrl = try await authorizedService.getCredentialAuthorizationUrl(
     credentialInfo: credential,
-    documents: unsignedDocuments,
+    documents: unsignedDocuments
 )
 
 // Use the credentialAuthorizationUrl to open a browser and let the user authorize the credential

--- a/Sources/RqesKit/RQESServiceCredentialAuthorized.swift
+++ b/Sources/RqesKit/RQESServiceCredentialAuthorized.swift
@@ -22,7 +22,7 @@ import SwiftASN1
 
 public typealias SigningAlgorithmOID = RQESLib.SigningAlgorithmOID
 /// The authorized credential is used to sign the documents. The list of documents that will be signed using the authorized credential are the documents
-/// that were passed to the ``RQESServiceAuthorizedProtocol.getCredentialAuthorizationUrl`` method.
+/// that were passed to the ``RQESServiceAuthorizedProtocol.`` method.
 public class RQESServiceCredentialAuthorized: RQESServiceCredentialAuthorizedProtocol, @unchecked Sendable {
     var rqes: RQES
     var clientConfig: CSCClientConfig

--- a/Sources/RqesKit/RqesProtocols.swift
+++ b/Sources/RqesKit/RqesProtocols.swift
@@ -51,7 +51,7 @@ public protocol RQESServiceAuthorizedProtocol {
 	/// - Parameters:
 	///   - credentialInfo: Information about the credential.
 	///   - documents: An array of documents that will be signed.
-	///   - hashAlgorithmOID: The object identifier (OID) of the hash algorithm to be used, optinal.
+	///   - hashAlgorithmOID: The object identifier (OID) of the hash algorithm to be used, optional.
 	///   - certificates: An optional array of X509 certificates.
 	/// - Returns: The credential authorization URL
 	/// The credential authorization URL is used to authorize the credential that will be used to sign the documents.


### PR DESCRIPTION
Clarify the documentation for RQES service methods, including corrections to method descriptions and parameter details. Remove outdated examples and improve overall clarity.